### PR TITLE
consider that some gemspecs contain trailing slash

### DIFF
--- a/bin/bundle-star
+++ b/bin/bundle-star
@@ -56,6 +56,7 @@ module Bundler
 
     def repository
       url = installer.spec.homepage
+      url.sub!(/\/$/, '') if url # some gems contain trailing slash
       if url =~ /\Ahttps?:\/\/([^.]+)?\.?github.com\/(.+)/
         if $1 == nil
           $2


### PR DESCRIPTION
Some gems contain trailing slash. For example:
```
mime-types/ruby-mime-types
rtomayko/tilt
```

close #7